### PR TITLE
[FIX] use int64 for segment coordinates

### DIFF
--- a/include/stellar/options/dream_options.hpp
+++ b/include/stellar/options/dream_options.hpp
@@ -11,8 +11,8 @@ struct DREAMOptions
 
     // Specify the segment (and sequence) of interest.
     unsigned sequenceOfInterest;
-    unsigned segmentBegin;
-    unsigned segmentEnd;
+    uint64_t segmentBegin;
+    uint64_t segmentEnd;
 };
 
 } // namespace stellar

--- a/src/stellar/stellar.arg_parser.cpp
+++ b/src/stellar/stellar.arg_parser.cpp
@@ -153,8 +153,8 @@ void _setParser(ArgumentParser & parser)
     // Valik prefiltering associates each query to a segment
     // DREAM-Stellar should search a segment for seeds and extend them in a complete reference sequence (not the complete database)
     addOption(parser, ArgParseOption("", "sequenceOfInterest", "Database sequence that contains segment (0-based).", ArgParseArgument::INTEGER));
-    addOption(parser, ArgParseOption("", "segmentBegin", "Segment begin in database sequence (included).", ArgParseArgument::INTEGER));
-    addOption(parser, ArgParseOption("", "segmentEnd", "Segment end in database sequence (excluded).", ArgParseArgument::INTEGER));
+    addOption(parser, ArgParseOption("", "segmentBegin", "Segment begin in database sequence (included).", ArgParseArgument::INT64));
+    addOption(parser, ArgParseOption("", "segmentEnd", "Segment end in database sequence (excluded).", ArgParseArgument::INT64));
 
     addSection(parser, "Filtering Options");
 


### PR DESCRIPTION
TODO: still segfaults for 4GB database with large `--segmentBegin --segmentEnd`


Notes on workflow structure:
* Each instance of Stellar3 will search for matches within a segment sequence but extend the match in the full chromosome. 
* Multiple instances of Stellar3 will have to keep the same chromosome in memory. 
* Moving Stellar3 to live within Valik would allow multiple Stellar3 searches to access the same memory (i.e the same copy of the chromosome sequence). Advantage: reduce overall RAM usage. Disadvantage: must run on single machine. 